### PR TITLE
Added validation for command 'dotnet' and change 'zsh' to 'bash'

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,4 +1,9 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+
+if ! command -v dotnet &> /dev/null; then
+    echo "Please, install dotnet!!"
+    exit 1
+fi
 
 dotnet tool uninstall --tool-path $HOME/Tools httpdoom 2>/dev/null
 


### PR DESCRIPTION

I think it is better to change the interpreter to bash, it is the default of almost all linux distros, even if it is not default, it is installed. I also added a validation for the 'dotnet' command.

